### PR TITLE
lexer full review

### DIFF
--- a/pag-lexer/Cargo.toml
+++ b/pag-lexer/Cargo.toml
@@ -26,4 +26,4 @@ readme = "README.md"
 [dependencies]
 quote = "1.0.26"
 proc-macro2 = "1.0"
-smallvec = "1"
+smallvec = { version = "1", features = ["union"] }

--- a/pag-lexer/src/congruence.rs
+++ b/pag-lexer/src/congruence.rs
@@ -20,20 +20,15 @@ pub fn meet(a: &[Intervals], b: &[Intervals]) -> Vec<Intervals> {
         }
     }
     result.sort();
-    result.dedup_by(|x, y| x == y);
+    result.dedup();
     result
 }
 
 pub fn approximate_congruence_class(tree: &RegexTree) -> Vec<Intervals> {
+    use RegexTree::*;
     match tree {
-        RegexTree::Epsilon => vec![unsafe { intervals!((0, u8::MAX)).unwrap_unchecked() }],
-        RegexTree::Top => {
-            vec![unsafe { intervals!((0, u8::MAX)).unwrap_unchecked() }]
-        }
-        RegexTree::Bottom => {
-            vec![unsafe { intervals!((0, u8::MAX)).unwrap_unchecked() }]
-        }
-        RegexTree::Set(x) => {
+        Epsilon | Top | Bottom => vec![intervals!((0, u8::MAX))],
+        Set(x) => {
             let x = x.clone();
             match x.complement() {
                 Some(y) => {
@@ -46,7 +41,7 @@ pub fn approximate_congruence_class(tree: &RegexTree) -> Vec<Intervals> {
                 None => vec![x],
             }
         }
-        RegexTree::Concat(r, s) => {
+        Concat(r, s) => {
             if !r.is_nullable() {
                 approximate_congruence_class(r)
             } else {
@@ -56,15 +51,10 @@ pub fn approximate_congruence_class(tree: &RegexTree) -> Vec<Intervals> {
                 )
             }
         }
-        RegexTree::KleeneClosure(r) => approximate_congruence_class(r),
-        RegexTree::Union(r, s) => meet(
+        KleeneClosure(r) | Complement(r) => approximate_congruence_class(r),
+        Union(r, s) | Intersection(r, s) => meet(
             &approximate_congruence_class(r),
             &approximate_congruence_class(s),
         ),
-        RegexTree::Intersection(r, s) => meet(
-            &approximate_congruence_class(r),
-            &approximate_congruence_class(s),
-        ),
-        RegexTree::Complement(r) => approximate_congruence_class(r),
     }
 }

--- a/pag-lexer/src/derivative.rs
+++ b/pag-lexer/src/derivative.rs
@@ -10,36 +10,35 @@ use crate::regex_tree::RegexTree;
 use std::rc::Rc;
 
 pub fn derivative(tree: Rc<RegexTree>, x: u8) -> RegexTree {
+    use RegexTree::*;
     match tree.as_ref() {
-        RegexTree::Set(set) => {
+        Set(set) => {
             if set.contains(x) {
-                RegexTree::Epsilon
+                Epsilon
             } else {
-                RegexTree::Bottom
+                Bottom
             }
         }
-        RegexTree::Epsilon => RegexTree::Bottom,
-        RegexTree::Concat(r, s) => {
-            let lhs = RegexTree::Concat(Rc::new(derivative(r.clone(), x)), s.clone());
+        Epsilon => Bottom,
+        Concat(r, s) => {
+            let lhs = Concat(Rc::new(derivative(r.clone(), x)), s.clone());
             if r.is_nullable() {
-                RegexTree::Union(Rc::new(lhs), Rc::new(derivative(s.clone(), x)))
+                Union(Rc::new(lhs), Rc::new(derivative(s.clone(), x)))
             } else {
                 lhs
             }
         }
-        RegexTree::KleeneClosure(r) => {
-            RegexTree::Concat(Rc::new(derivative(r.clone(), x)), tree.clone())
-        }
-        RegexTree::Union(r, s) => RegexTree::Union(
+        KleeneClosure(r) => Concat(Rc::new(derivative(r.clone(), x)), tree.clone()),
+        Union(r, s) => Union(
             Rc::new(derivative(r.clone(), x)),
             Rc::new(derivative(s.clone(), x)),
         ),
-        RegexTree::Intersection(r, s) => RegexTree::Intersection(
+        Intersection(r, s) => Intersection(
             Rc::new(derivative(r.clone(), x)),
             Rc::new(derivative(s.clone(), x)),
         ),
-        RegexTree::Complement(r) => RegexTree::Complement(Rc::new(derivative(r.clone(), x))),
-        RegexTree::Top => RegexTree::Epsilon,
-        RegexTree::Bottom => RegexTree::Bottom,
+        Complement(r) => Complement(Rc::new(derivative(r.clone(), x))),
+        Top => Epsilon,
+        Bottom => Bottom,
     }
 }

--- a/pag-lexer/src/intervals.rs
+++ b/pag-lexer/src/intervals.rs
@@ -6,7 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 use quote::{quote, ToTokens};
 use smallvec::{smallvec, SmallVec};
 use std::ascii::escape_default;
@@ -220,17 +220,16 @@ impl Display for Intervals {
     }
 }
 
+pub fn byte_char(c: u8) -> Literal {
+    format!("b'{}'", escape_default(c)).parse().unwrap()
+}
+
 impl ToTokens for Intervals {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         debug_assert!(!self.0.is_empty());
         let iter = self.0.iter().map(|Interval(start, end)| {
-            let to_byte_char = |c: u8| {
-                format!("b'{}'", escape_default(c))
-                    .parse::<proc_macro2::Literal>()
-                    .unwrap()
-            };
-            let start_lit = to_byte_char(*start);
-            let end_lit = to_byte_char(*end);
+            let start_lit = byte_char(*start);
+            let end_lit = byte_char(*end);
             if start == end {
                 quote! { #start_lit }
             } else {

--- a/pag-lexer/src/lib.rs
+++ b/pag-lexer/src/lib.rs
@@ -6,10 +6,6 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-#![feature(let_chains)]
-#![feature(array_chunks)]
-#![feature(portable_simd)]
-
 pub mod congruence;
 pub mod derivative;
 pub mod intervals;

--- a/pag-lexer/src/lookahead.rs
+++ b/pag-lexer/src/lookahead.rs
@@ -6,7 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use crate::intervals::Intervals;
+use crate::intervals::{byte_char, Intervals};
 use crate::vector::{DfaTable, Vector};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -33,19 +33,22 @@ fn generate_lut_routine(index: usize) -> TokenStream {
 }
 
 fn byte_simd(byte: u8) -> TokenStream {
+    let byte_lit = byte_char(byte);
     quote! {
         {
-            let needles = u8x16::splat(#byte);
+            let needles = u8x16::splat(#byte_lit);
             data.simd_eq(needles)
         }
     }
 }
 
 fn range_simd(min: u8, max: u8) -> TokenStream {
+    let min_lit = byte_char(min);
+    let max_lit = byte_char(max);
     quote! {
         {
-            let needles_min = u8x16::splat(#min);
-            let needles_max = u8x16::splat(#max);
+            let needles_min = u8x16::splat(#min_lit);
+            let needles_max = u8x16::splat(#max_lit);
             let cmp_min = data.simd_ge(needles_min);
             let cmp_max = data.simd_le(needles_max);
             cmp_min & cmp_max

--- a/pag-lexer/src/normalization.rs
+++ b/pag-lexer/src/normalization.rs
@@ -10,21 +10,23 @@ use crate::regex_tree::RegexTree;
 use std::rc::Rc;
 
 pub fn normalize(tree: Rc<RegexTree>) -> Rc<RegexTree> {
-    match tree.as_ref() {
-        RegexTree::Complement(r) => {
+    use RegexTree::*;
+    match &*tree {
+        Epsilon | Top | Bottom => tree,
+        Complement(r) => {
             let r = normalize(r.clone());
-            match r.as_ref() {
-                RegexTree::Set(x) => match x.complement() {
-                    Some(y) => Rc::new(RegexTree::Set(y)),
-                    None => Rc::new(RegexTree::Bottom),
+            match &*r {
+                Set(x) => match x.complement() {
+                    Some(y) => Rc::new(Set(y)),
+                    None => Rc::new(Bottom),
                 },
-                RegexTree::Complement(r) => r.clone(),
-                RegexTree::Top => Rc::new(RegexTree::Bottom),
-                RegexTree::Bottom => Rc::new(RegexTree::Top),
-                _ => Rc::new(RegexTree::Complement(r)),
+                Complement(r) => r.clone(),
+                Top => Rc::new(Bottom),
+                Bottom => Rc::new(Top),
+                _ => Rc::new(Complement(r)),
             }
         }
-        RegexTree::Intersection(r, s) => {
+        Intersection(r, s) => {
             // referential equality
             if Rc::ptr_eq(r, s) {
                 return normalize(r.clone());
@@ -32,17 +34,17 @@ pub fn normalize(tree: Rc<RegexTree>) -> Rc<RegexTree> {
             let r = normalize(r.clone());
             let s = normalize(s.clone());
             // empty & r = empty
-            if matches!(r.as_ref(), RegexTree::Bottom) {
+            if matches!(&*r, Bottom) {
                 return r;
             }
-            if matches!(s.as_ref(), RegexTree::Bottom) {
+            if matches!(&*s, Bottom) {
                 return s;
             }
             // any & r = r
-            if matches!(s.as_ref(), RegexTree::Top) {
+            if matches!(&*s, Top) {
                 return r;
             }
-            if matches!(r.as_ref(), RegexTree::Top) {
+            if matches!(&*r, Top) {
                 return s;
             }
 
@@ -50,82 +52,77 @@ pub fn normalize(tree: Rc<RegexTree>) -> Rc<RegexTree> {
             if ordering.is_eq() {
                 return r;
             }
-            if let RegexTree::Set(r) = r.as_ref()
-                && let RegexTree::Set(s) = s.as_ref() {
+            if let (Set(r), Set(s)) = (&*r, &*s) {
                 return match r.intersection(s) {
-                    Some(set) => Rc::new(RegexTree::Set(set)),
-                    None => Rc::new(RegexTree::Bottom),
-                }
+                    Some(set) => Rc::new(Set(set)),
+                    None => Rc::new(Bottom),
+                };
             }
             // always right heavy
-            if let RegexTree::Intersection(r1, r2) = r.as_ref() {
-                return normalize(Rc::new(RegexTree::Intersection(
+            if let Intersection(r1, r2) = &*r {
+                return normalize(Rc::new(Intersection(
                     r1.clone(),
-                    Rc::new(RegexTree::Intersection(r2.clone(), s)),
+                    Rc::new(Intersection(r2.clone(), s)),
                 )));
             }
 
             // will not fall in any of the above cases -- it is safe to return
-            if ordering.is_lt() || matches!(s.as_ref(), RegexTree::Intersection(..)) {
-                Rc::new(RegexTree::Intersection(r, s))
+            if ordering.is_lt() || matches!(&*s, Intersection(..)) {
+                Rc::new(Intersection(r, s))
             } else {
-                Rc::new(RegexTree::Intersection(s, r))
+                Rc::new(Intersection(s, r))
             }
         }
-        RegexTree::Set(x) => {
+        Set(x) => {
             if x.is_full_set() {
-                Rc::new(RegexTree::Top)
+                Rc::new(Top)
             } else {
                 tree
             }
         }
-        RegexTree::Epsilon => tree,
-        RegexTree::Concat(r, s) => {
+        Concat(r, s) => {
             let nr = normalize(r.clone());
             let ns = normalize(s.clone());
             // empty . s = empty
-            if matches!(nr.as_ref(), RegexTree::Bottom) {
+            if matches!(&*nr, Bottom) {
                 return nr;
             }
             // r . empty = empty
-            if matches!(ns.as_ref(), RegexTree::Bottom) {
+            if matches!(&*ns, Bottom) {
                 return ns;
             }
             // r. epsilon = r
-            if matches!(ns.as_ref(), RegexTree::Epsilon) {
+            if matches!(&*ns, Epsilon) {
                 return nr;
             }
             // epsilon . s = s
-            if matches!(nr.as_ref(), RegexTree::Epsilon) {
+            if matches!(&*nr, Epsilon) {
                 return ns;
             }
-            if let RegexTree::Concat(r1, r2) = nr.as_ref() {
-                return normalize(Rc::new(RegexTree::Concat(
-                    r1.clone(),
-                    Rc::new(RegexTree::Concat(r2.clone(), ns)),
-                )));
+            if let Concat(r1, r2) = &*nr {
+                return normalize(Rc::new(Concat(r1.clone(), Rc::new(Concat(r2.clone(), ns)))));
             }
 
             if Rc::ptr_eq(&nr, r) && Rc::ptr_eq(&ns, s) {
                 return tree;
             }
-            Rc::new(RegexTree::Concat(nr, ns))
+            Rc::new(Concat(nr, ns))
         }
-        RegexTree::KleeneClosure(r) => {
+        KleeneClosure(r) => {
             let nr = normalize(r.clone());
-            match nr.as_ref() {
-                RegexTree::KleeneClosure(_) => nr,
-                RegexTree::Bottom => Rc::new(RegexTree::Epsilon),
-                RegexTree::Epsilon => Rc::new(RegexTree::Epsilon),
+            match &*nr {
+                KleeneClosure(_) => nr,
+                Bottom => Rc::new(Epsilon),
+                Epsilon => Rc::new(Epsilon),
                 _ => {
                     if Rc::ptr_eq(r, &nr) {
                         return tree;
                     }
-                    Rc::new(RegexTree::KleeneClosure(nr))
+                    Rc::new(KleeneClosure(nr))
                 }
             }
         }
-        RegexTree::Union(r, s) => {
+        Union(r, s) => {
             // referential equality
             if Rc::ptr_eq(r, s) {
                 return normalize(r.clone());
@@ -134,61 +131,54 @@ pub fn normalize(tree: Rc<RegexTree>) -> Rc<RegexTree> {
             let s = normalize(s.clone());
 
             // empty | r = r
-            if matches!(r.as_ref(), RegexTree::Bottom) {
+            if matches!(&*r, Bottom) {
                 return s;
             }
-            if matches!(s.as_ref(), RegexTree::Bottom) {
+            if matches!(&*s, Bottom) {
                 return r;
             }
             // any | r = any
-            if matches!(s.as_ref(), RegexTree::Top) {
+            if matches!(&*s, Top) {
                 return s;
             }
-            if matches!(r.as_ref(), RegexTree::Top) {
+            if matches!(&*r, Top) {
                 return r;
             }
             let ordering = r.cmp(&s);
             if ordering.is_eq() {
                 return r;
             }
-            if let RegexTree::Set(r) = r.as_ref()
-                && let RegexTree::Set(s) = s.as_ref() {
-                return Rc::new(RegexTree::Set(r.union(s)));
+            if let (Set(r), Set(s)) = (&*r, &*s) {
+                return Rc::new(Set(r.union(s)));
             }
 
             // distributive
-            if let RegexTree::Concat(r1, r2) = r.as_ref() &&
-                let RegexTree::Concat(s1, s2) = s.as_ref() {
+            if let (Concat(r1, r2), Concat(s1, s2)) = (&*r, &*s) {
                 if r1 == s1 {
-                    return normalize(Rc::new(RegexTree::Concat(
+                    return normalize(Rc::new(Concat(
                         r1.clone(),
-                        Rc::new(RegexTree::Union(r2.clone(), s2.clone())),
+                        Rc::new(Union(r2.clone(), s2.clone())),
                     )));
                 }
                 if r2 == s2 {
-                    return normalize(Rc::new(RegexTree::Concat(
-                        Rc::new(RegexTree::Union(r1.clone(), s1.clone())),
+                    return normalize(Rc::new(Concat(
+                        Rc::new(Union(r1.clone(), s1.clone())),
                         r2.clone(),
                     )));
                 }
             }
 
             // always right heavy
-            if let RegexTree::Union(r1, r2) = r.as_ref() {
-                return normalize(Rc::new(RegexTree::Union(
-                    r1.clone(),
-                    Rc::new(RegexTree::Union(r2.clone(), s)),
-                )));
+            if let Union(r1, r2) = &*r {
+                return normalize(Rc::new(Union(r1.clone(), Rc::new(Union(r2.clone(), s)))));
             }
 
             // will not fall in any of the above cases -- it is safe to return
-            if ordering.is_lt() || matches!(s.as_ref(), RegexTree::Union(..)) {
-                Rc::new(RegexTree::Union(r, s))
+            if ordering.is_lt() || matches!(&*s, Union(..)) {
+                Rc::new(Union(r, s))
             } else {
-                Rc::new(RegexTree::Union(s, r))
+                Rc::new(Union(s, r))
             }
         }
-        RegexTree::Top => tree,
-        RegexTree::Bottom => tree,
     }
 }

--- a/pag-parser/Cargo.toml
+++ b/pag-parser/Cargo.toml
@@ -25,7 +25,7 @@ readme = "README.md"
 [dependencies]
 pest = { version = "2.5.7", features = [ "std", "memchr" ] }
 pest_derive = "2.5.7"
-smallvec = "1"
+smallvec = { version = "1", features = ["union"] }
 thiserror = "1"
 lazy_static = "1"
 pag-lexer = { version = "0.1.0-alpha.1", path = "../pag-lexer"}


### PR DESCRIPTION
Includes:

- Abuse `use RegexTree::*`.
- Force `intervals!` to accept at least 1 argument so that we can do `unwrap` safely inside.
- Enable `union` feature of smallvec.
- Change `struct Intervals(SmallVec<[Interval; 2]>)` to `struct Intervals(SmallVec<[Interval; 8]>)` because why not, there's no extra space cost.
- Remove nightly features.
- Some rewrites.

There are no performance changes. If you don't like it, just reject it.