### PR TITLE
Auto infer fixpoints

### DIFF
--- a/benches/csv/csv.pag
+++ b/benches/csv/csv.pag
@@ -6,12 +6,12 @@ lexer {
 }
 
 parser csv {
-    active definition csv
+    active csv
         = record+;
 
-    active definition field
-        = TEXT | STRING; 
+    active field
+        = TEXT | STRING;
 
-    active definition record
-        = field ~ (COMMA ~ field)* ~ CRLF;  
+    active record
+        = field ~ (COMMA ~ field)* ~ CRLF;
 }

--- a/benches/json/json.pag
+++ b/benches/json/json.pag
@@ -19,22 +19,22 @@ lexer {
 }
 
 parser json {
-    active definition attribute = 
+    active attribute =
         string ~ COLON ~ value;
 
-    active definition string = STRING;
-    active definition number = NUMBER;
-    active definition lit_true = TRUE;
-    active definition lit_false = FALSE;
-    active definition lit_null = NULL;
+    active string = STRING;
+    active number = NUMBER;
+    active lit_true = TRUE;
+    active lit_false = FALSE;
+    active lit_null = NULL;
 
-    active fixpoint object = 
+    active object =
         LBRACKET ~ (attribute ~ (COMMA ~ attribute)*)? ~ RBRACKET;
-    
-    active fixpoint array = 
+
+    active array =
         LSQUARE ~ (value ~ (COMMA ~ value)*)? ~ RSQUARE;
 
-    silent fixpoint value = string | number | array | object | lit_true | lit_false | lit_null;
+    silent value = string | number | array | object | lit_true | lit_false | lit_null;
 
-    active definition json = value;
+    active json = value;
 }

--- a/pag-parser/Cargo.toml
+++ b/pag-parser/Cargo.toml
@@ -17,18 +17,20 @@ categories = ["parsing"]
 repository = "https://github.com/SchrodingerZhu/paguroidea"
 description = "Parser-lexer fusion generator (parser generator)"
 rust-version = "1.71.0"
-authors = ["Schrodinger ZHU Yifan <i@zhuyi.fan>", "QuarticCat <QuarticCat@pm.me>"]
+authors = [
+    "Schrodinger ZHU Yifan <i@zhuyi.fan>",
+    "QuarticCat <QuarticCat@pm.me>",
+]
 documentation = "https://docs.rs/pag-parser/"
 readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pest = { version = "2.5.7", features = [ "std", "memchr" ] }
+pest = { version = "2.5.7", features = ["std", "memchr"] }
 pest_derive = "2.5.7"
 smallvec = { version = "1", features = ["union"] }
-thiserror = "1"
 lazy_static = "1"
-pag-lexer = { version = "0.1.0-alpha.1", path = "../pag-lexer"}
+pag-lexer = { version = "0.1.0-alpha.1", path = "../pag-lexer" }
 typed-arena = "2.0.2"
 quote = "1.0.26"
 proc-macro2 = "1.0"

--- a/pag-parser/src/core_syntax.rs
+++ b/pag-parser/src/core_syntax.rs
@@ -19,7 +19,6 @@ pub enum Term<'src, 'a> {
     LexerRef(Symbol<'src>),
     Bottom,
     Alternative(&'a WithSpan<'src, Self>, &'a WithSpan<'src, Self>),
-    // Star(&'a WithSpan<'src, Self>),
     Fix(Symbol<'src>, &'a WithSpan<'src, Self>),
     ParserRef(Symbol<'src>),
 }
@@ -45,27 +44,13 @@ pub type BindingContext<'src, 'a> = HashMap<Symbol<'src>, ParserRule<'src, 'a>>;
 impl<'src, 'a> Display for Term<'src, 'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Term::Epsilon => {
-                write!(f, "ε")
-            }
-            Term::Sequence(x, y) => {
-                write!(f, "({x} ~ {y})",)
-            }
-            Term::LexerRef(x) => {
-                write!(f, "{x}")
-            }
-            Term::Bottom => {
-                write!(f, "⊥")
-            }
-            Term::Alternative(x, y) => {
-                write!(f, "({x} | {y})")
-            }
-            Term::Fix(x, y) => {
-                write!(f, "(μ {x} . {y})",)
-            }
-            Term::ParserRef(x) => {
-                write!(f, "{x}")
-            }
+            Term::Epsilon => write!(f, "ε"),
+            Term::Sequence(x, y) => write!(f, "({x} ~ {y})"),
+            Term::LexerRef(x) => write!(f, "{x}"),
+            Term::Bottom => write!(f, "⊥"),
+            Term::Alternative(x, y) => write!(f, "({x} | {y})"),
+            Term::Fix(x, y) => write!(f, "(μ {x} . {y})"),
+            Term::ParserRef(x) => write!(f, "{x}"),
         }
     }
 }

--- a/pag-parser/src/frontend/example.pag
+++ b/pag-parser/src/frontend/example.pag
@@ -13,15 +13,15 @@ lexer {
 parser sexpr {
     // definition in parser can be a real grammer rule.
 
-    active fixpoint compound
+    active compound
         = LPAREN ~ sexprs ~ RPAREN;
 
-    active definition atom
-        = ATOM;    
+    active atom
+        = ATOM;
 
-    silent definition sexprs
+    silent sexprs
         = (compound | atom) *;
 
-    active definition sexpr
+    active sexpr
         = compound | atom;
 }

--- a/pag-parser/src/frontend/fixpoint.rs
+++ b/pag-parser/src/frontend/fixpoint.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Paguroidea Developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+// Modified from Tarjan's strongly connected components algorithm
+
+use std::cell::Cell;
+use std::collections::HashMap;
+
+use super::{
+    SurfaceSyntaxTree::{self, *},
+    WithSpan,
+};
+
+type NodeId = u32;
+
+#[derive(Default)]
+struct Node {
+    neighbors: Vec<NodeId>,
+    in_stack: Cell<bool>,
+    low: Cell<u32>,
+    dfn: Cell<u32>,
+    in_cycle: Cell<bool>, // scc size > 1 or self reference
+}
+
+type Graph = Vec<Node>;
+
+fn find_neighbors<'src>(
+    sst: &WithSpan<'src, SurfaceSyntaxTree<'src>>,
+    neighbors: &mut Vec<NodeId>,
+    id_table: &HashMap<&'src str, NodeId>,
+) {
+    match &sst.node {
+        ParserAlternative { lhs, rhs } | ParserSequence { lhs, rhs } => {
+            find_neighbors(lhs, neighbors, id_table);
+            find_neighbors(rhs, neighbors, id_table);
+        }
+        ParserStar { inner } | ParserPlus { inner } | ParserOptional { inner } => {
+            find_neighbors(inner, neighbors, id_table);
+        }
+        ParserRuleRef { name } => {
+            // TODO: error handling
+            neighbors.push(*id_table.get(name.span.as_str()).unwrap());
+        }
+        _ => {}
+    }
+}
+
+fn construct_graph<'src>(sst: &WithSpan<'src, SurfaceSyntaxTree<'src>>) -> Graph {
+    let ParserDef { rules, .. } = &sst.node else {
+        unreachable!("sst should be a parser definition")
+    };
+
+    let mut id_table = HashMap::new();
+    for (idx, rule) in rules.iter().enumerate() {
+        let ParserRuleDef { name, .. } = &rule.node else {
+            unreachable!("parser should only contain rule definitions")
+        };
+        id_table.insert(name.span.as_str(), idx as NodeId);
+    }
+
+    let mut nodes = Vec::new();
+    for (idx, rule) in rules.iter().enumerate() {
+        let ParserRuleDef { expr, .. } = &rule.node else {
+            unreachable!("parser should only contain rule definitions")
+        };
+        let mut neighbors = Vec::new();
+        find_neighbors(&expr, &mut neighbors, &id_table);
+        // self reference
+        let in_cycle = Cell::new(neighbors.iter().find(|id| **id == idx as _).is_some());
+        nodes.push(Node {
+            neighbors,
+            in_cycle,
+            ..Node::default()
+        })
+    }
+
+    nodes
+}
+
+fn tarjan(node_id: NodeId, dfn_cnt: &mut u32, stack: &mut Vec<NodeId>, graph: &Graph) {
+    let node = &graph[node_id as usize];
+
+    *dfn_cnt += 1;
+    node.low.set(*dfn_cnt);
+    node.dfn.set(*dfn_cnt);
+    stack.push(node_id);
+    node.in_stack.set(true);
+
+    for &next_id in &node.neighbors {
+        let next = &graph[next_id as usize];
+        if next.dfn.get() == 0 {
+            tarjan(next_id, dfn_cnt, stack, graph);
+            node.low.set(node.low.get().min(next.low.get()))
+        } else if next.in_stack.get() {
+            node.low.set(node.low.get().min(next.dfn.get()))
+        }
+    }
+
+    if node.low.get() == node.dfn.get() {
+        // scc size == 1
+        if stack.last() == Some(&node_id) {
+            node.in_stack.set(false);
+            stack.pop();
+            return;
+        }
+        // scc size > 1
+        while let Some(top_id) = stack.pop() {
+            let top = &graph[top_id as usize];
+            top.in_stack.set(false);
+            top.in_cycle.set(true);
+            if top_id == node_id {
+                break;
+            }
+        }
+    }
+}
+
+pub fn infer_fixpoints<'src>(sst: &mut WithSpan<'src, SurfaceSyntaxTree<'src>>) {
+    let graph = construct_graph(sst);
+    let mut dfn_cnt = 0;
+    let mut stack = Vec::new();
+
+    for (id, node) in graph.iter().enumerate() {
+        if node.dfn.get() == 0 {
+            tarjan(id as NodeId, &mut dfn_cnt, &mut stack, &graph);
+        }
+    }
+
+    let ParserDef { rules, .. } = &mut sst.node else {
+        unreachable!("sst should be a parser definition")
+    };
+    for (id, node) in graph.iter().enumerate() {
+        if node.in_cycle.get() {
+            let ParserRuleDef { fixpoint, .. } = &mut rules[id].node else {
+                unreachable!("parser should only contain rule definitions")
+            };
+            *fixpoint = true;
+        }
+    }
+}

--- a/pag-parser/src/frontend/grammar.pest
+++ b/pag-parser/src/frontend/grammar.pest
@@ -7,9 +7,8 @@ lexer = _{ "lexer" }
 parser = _{ "parser" }
 empty = { "_" }
 definition = _{ "definition" }
-fixpoint = _{ "fixpoint" }
 
-KEYWORD = { any | active | empty | bottom | silent | token | lexer | parser | definition | fixpoint }
+KEYWORD = { any | active | empty | bottom | silent | token | lexer | parser | definition }
 
 /// A newline character.
 newline = _{ "\n" | "\r\n" }
@@ -72,12 +71,8 @@ silent_token = { silent ~ token ~ token_id ~ "=" ~ lexical_expr }
 
 // parser definition
 parser_def = { parser ~ parser_id ~ "{" ~ parser_rules ~ "}" }
-parser_rules = { ( (parser_fixpoint | parser_definition) ~ ";")+ }
-parser_definition = _{ active_parser_definition | silent_parser_definition }
-active_parser_definition = { active ~ definition ~ parser_id ~ "=" ~ parser_expr }
-silent_parser_definition = { silent ~ definition ~ parser_id ~ "=" ~ parser_expr }
-parser_fixpoint = _{ active_parser_fixpoint | silent_parser_fixpoint }
-active_parser_fixpoint = { active ~ fixpoint ~ parser_id ~ "=" ~ parser_expr }
-silent_parser_fixpoint = { silent ~ fixpoint ~ parser_id ~ "=" ~ parser_expr }
+parser_rules = { ( (active_parser_rule | silent_parser_rule) ~ ";")+ }
+active_parser_rule = { active ~ parser_id ~ "=" ~ parser_expr }
+silent_parser_rule = { silent ~ parser_id ~ "=" ~ parser_expr }
 
 grammar = { SOI ~ lexer_def ~ parser_def ~ EOI }

--- a/pag-parser/src/frontend/lexical.rs
+++ b/pag-parser/src/frontend/lexical.rs
@@ -112,8 +112,8 @@ where
             let inner = construct_regex_tree(inner, reference_handler)?;
             Ok(Rc::new(RegexTree::Complement(inner)))
         }
-        SurfaceSyntaxTree::Range { start, end } => Ok(unicode::encode_range(*start, *end)),
-        SurfaceSyntaxTree::String(x) => {
+        SurfaceSyntaxTree::RangeLit { start, end } => Ok(unicode::encode_range(*start, *end)),
+        SurfaceSyntaxTree::StringLit(x) => {
             if x.is_empty() {
                 Ok(Rc::new(RegexTree::Epsilon))
             } else {
@@ -126,7 +126,7 @@ where
         }
         SurfaceSyntaxTree::Bottom => Ok(Rc::new(RegexTree::Bottom)),
         SurfaceSyntaxTree::Empty => Ok(Rc::new(RegexTree::Epsilon)),
-        SurfaceSyntaxTree::Char { value } => Ok(unicode::encode_char(value.node)),
+        SurfaceSyntaxTree::CharLit { value } => Ok(unicode::encode_char(value.node)),
         SurfaceSyntaxTree::LexicalRuleRef { name } => reference_handler(name.clone()),
         _ => unreachable_branch!(
             "lexer translation is called with unsupported code: {}",
@@ -213,7 +213,7 @@ impl<'a> TranslationContext<'a> {
         sst: &WithSpan<'a, SurfaceSyntaxTree<'a>>,
     ) -> Result<(), Vec<WithSpan<'a, Error<'a>>>> {
         match &sst.node {
-            SurfaceSyntaxTree::Lexer { rules } => {
+            SurfaceSyntaxTree::LexerDef { rules } => {
                 let mut error = Vec::new();
                 for i in rules
                     .iter()
@@ -261,7 +261,7 @@ impl<'a> TranslationContext<'a> {
             Err(errs) => errs,
         };
         match &sst.node {
-            SurfaceSyntaxTree::Lexer { rules } => {
+            SurfaceSyntaxTree::LexerDef { rules } => {
                 for i in rules
                     .iter()
                     .filter_map(|x| match &x.node {

--- a/pag-parser/src/frontend/mod.rs
+++ b/pag-parser/src/frontend/mod.rs
@@ -289,7 +289,7 @@ pub enum SurfaceSyntaxTree<'a> {
     },
 }
 
-fn parse_surface_syntax<'a, I: Iterator<Item = Pair<'a, Rule>>>(
+fn parse_surface_syntax<'a, I: IntoIterator<Item = Pair<'a, Rule>>>(
     pairs: I,
     pratt: &PrattParser<Rule>,
     src: &'a str,
@@ -302,8 +302,8 @@ fn parse_surface_syntax<'a, I: Iterator<Item = Pair<'a, Rule>>>(
                     let mut grammar = primary.into_inner();
                     let lexer = grammar.next().ok_or_else(|| unexpected_eoi!("lexer"))?;
                     let parser = grammar.next().ok_or_else(|| unexpected_eoi!("parser"))?;
-                    let lexer = parse_surface_syntax([lexer].into_iter(), pratt, src)?;
-                    let parser = parse_surface_syntax([parser].into_iter(), pratt, src)?;
+                    let lexer = parse_surface_syntax([lexer], pratt, src)?;
+                    let parser = parse_surface_syntax([parser], pratt, src)?;
                     Ok(WithSpan {
                         span,
                         node: SurfaceSyntaxTree::Grammar {
@@ -319,7 +319,7 @@ fn parse_surface_syntax<'a, I: Iterator<Item = Pair<'a, Rule>>>(
                         .ok_or_else(|| unexpected_eoi!("lexer rules"))?;
                     let rules = lexer_rules.into_inner().fold(Ok(Vec::new()), |acc, rule| {
                         acc.and_then(|vec| {
-                            parse_surface_syntax([rule].into_iter(), pratt, src).map(|rule| {
+                            parse_surface_syntax([rule], pratt, src).map(|rule| {
                                 let mut vec = vec;
                                 vec.push(rule);
                                 vec
@@ -468,7 +468,7 @@ fn parse_surface_syntax<'a, I: Iterator<Item = Pair<'a, Rule>>>(
                         .into_inner()
                         .fold(Ok(Vec::new()), |acc, rule| {
                             acc.and_then(|vec| {
-                                parse_surface_syntax([rule].into_iter(), pratt, src).map(|rule| {
+                                parse_surface_syntax([rule], pratt, src).map(|rule| {
                                     let mut vec = vec;
                                     vec.push(rule);
                                     vec
@@ -631,7 +631,7 @@ fn parse_surface_syntax<'a, I: Iterator<Item = Pair<'a, Rule>>>(
                 _ => unreachable_branch!("Operator {} is not a postfix operator", op.as_str()),
             }
         })
-        .parse(pairs)
+        .parse(pairs.into_iter())
 }
 
 pub fn parse(input: &str) -> Result<WithSpan<SurfaceSyntaxTree>, crate::Error> {

--- a/pag-parser/src/frontend/mod.rs
+++ b/pag-parser/src/frontend/mod.rs
@@ -6,6 +6,10 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+pub mod lexical;
+pub mod syntax;
+pub mod unicode;
+
 use lazy_static::lazy_static;
 use pest::iterators::Pair;
 use pest::pratt_parser::{Op, PrattParser};
@@ -13,16 +17,13 @@ use pest::Span;
 use std::borrow::Cow;
 use std::fmt::Display;
 use thiserror::Error;
-pub mod lexical;
-pub mod syntax;
-pub mod unicode;
 
 #[derive(Error, Debug, Clone)]
 pub enum Error<'a> {
     #[error("internal logic error: {0}")]
     InternalLogicalError(Cow<'a, str>),
     #[error("multiple definition for {0}")]
-    MultipleDefinition(&'a str, pest::Span<'a>),
+    MultipleDefinition(&'a str, Span<'a>),
     #[error("lexical reference {0} is not allowed within lexical definitions")]
     InvalidLexicalReference(&'a str),
     #[error("multiple skip rule detected, previous definition is {0}")]

--- a/pag-parser/src/frontend/mod.rs
+++ b/pag-parser/src/frontend/mod.rs
@@ -35,12 +35,15 @@ pub enum Error<'a> {
     UndefinedParserRuleReference(&'a str),
 }
 
+pub type FrontendErrors<'a> = Vec<WithSpan<'a, Error<'a>>>;
+pub type FrontendResult<'a, T> = Result<T, FrontendErrors<'a>>;
+
 #[macro_export]
 macro_rules! span_errors {
     ($ekind:ident, $span:expr, $($params:expr,)*) => {
         vec![WithSpan {
             span: $span,
-            node: Error::$ekind ($($params,)*)
+            node: $crate::frontend::Error::$ekind($($params,)*)
         }]
     };
 }

--- a/pag-parser/src/frontend/mod.rs
+++ b/pag-parser/src/frontend/mod.rs
@@ -17,23 +17,15 @@ use pest::pratt_parser::{Op, PrattParser};
 use pest::Span;
 use std::borrow::Cow;
 use std::fmt::Display;
-use thiserror::Error;
 
-#[derive(Error, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum Error<'a> {
-    #[error("internal logic error: {0}")]
     InternalLogicalError(Cow<'a, str>),
-    #[error("multiple definition for {0}")]
     MultipleDefinition(&'a str, Span<'a>),
-    #[error("lexical reference {0} is not allowed within lexical definitions")]
     InvalidLexicalReference(&'a str),
-    #[error("multiple skip rule detected, previous definition is {0}")]
     MultipleSkippingRule(&'a str),
-    #[error("nullable token {0} is prohibited")]
     NullableToken(&'a str),
-    #[error("lexical {0} is undefined")]
     UndefinedLexicalReference(&'a str),
-    #[error("parser rule {0} is undefined")]
     UndefinedParserRuleReference(&'a str),
 }
 
@@ -103,15 +95,11 @@ use crate::utilities::unreachable_branch;
 pub use grammar::Parser as GrammarParser;
 pub use grammar::Rule;
 
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Clone)]
 pub enum GrammarDefinitionError<'a> {
-    #[error("grammar definition error: {0}")]
-    SyntaxError(#[from] Box<pest::error::Error<Rule>>),
-    #[error("failed to parse {}: {message}", span.as_str())]
+    SyntaxError(Box<pest::error::Error<Rule>>),
     FormatError { span: Span<'a>, message: String },
-    #[error("{0}")]
     ParserLogicError(Cow<'a, str>),
-    #[error("unexpected end of input, expecting {0}")]
     UnexpectedEOI(Cow<'a, str>),
 }
 

--- a/pag-parser/src/frontend/syntax.rs
+++ b/pag-parser/src/frontend/syntax.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     lexical::LexerDatabase,
-    Error,
+    FrontendResult,
     SurfaceSyntaxTree::{self, *},
     WithSpan,
 };
@@ -47,7 +47,7 @@ pub fn construct_parser<'src, 'a>(
     arena: &'a TermArena<'src, 'a>,
     lexer_database: LexerDatabase<'src>,
     sst: &WithSpan<'src, SurfaceSyntaxTree<'src>>,
-) -> Result<Parser<'src, 'a>, Vec<WithSpan<'src, Error<'src>>>> {
+) -> FrontendResult<'src, Parser<'src, 'a>> {
     let mut parser = Parser {
         entrypoint: Symbol::new(""),
         arena,
@@ -138,7 +138,7 @@ pub fn construct_parser<'src, 'a>(
 fn construct_symbol_table<'src>(
     context: &mut Parser<'src, '_>,
     sst: &WithSpan<'src, SurfaceSyntaxTree<'src>>,
-) -> Result<(), Vec<WithSpan<'src, Error<'src>>>> {
+) -> FrontendResult<'src, ()> {
     match &sst.node {
         ParserDef { rules, .. } => {
             for rule in rules {
@@ -175,7 +175,7 @@ fn construct_symbol_table<'src>(
 fn construct_core_syntax_tree<'src, 'a>(
     translation_context: &Parser<'src, 'a>,
     sst: &WithSpan<'src, SurfaceSyntaxTree<'src>>,
-) -> Result<TermPtr<'src, 'a>, Vec<WithSpan<'src, Error<'src>>>> {
+) -> FrontendResult<'src, TermPtr<'src, 'a>> {
     match &sst.node {
         ParserAlternative { lhs, rhs } => {
             let lhs = construct_core_syntax_tree(translation_context, lhs);

--- a/pag-parser/src/frontend/syntax.rs
+++ b/pag-parser/src/frontend/syntax.rs
@@ -32,13 +32,13 @@ impl<'src, 'a> Parser<'src, 'a> {
         let target = unsafe { self.bindings.get(&self.entrypoint).unwrap_unchecked() };
         type_check(&self.bindings, target.term, self.entrypoint)
     }
+
     pub fn is_active(&self, tag: &Tag<'src>) -> bool {
         !tag.is_versioned()
             && self
                 .bindings
                 .get(&tag.symbol())
-                .map(|x| x.active)
-                .unwrap_or(false)
+                .map_or(false, |x| x.active)
     }
 }
 

--- a/pag-parser/src/frontend/unicode.rs
+++ b/pag-parser/src/frontend/unicode.rs
@@ -5,6 +5,7 @@
 // license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
+
 use pag_lexer::normalization::normalize;
 use pag_lexer::regex_tree::RegexTree;
 use std::rc::Rc;

--- a/pag-parser/src/fusion.rs
+++ b/pag-parser/src/fusion.rs
@@ -451,12 +451,7 @@ pub fn fusion_parser<'src>(
         .entries
         .iter()
         .map(|(tag, rules)| {
-            if !tag.is_versioned()
-                && parser
-                    .bindings
-                    .get(&tag.symbol())
-                    .map_or(false, |x| x.active)
-            {
+            if parser.is_active(tag) {
                 generate_active_parser(
                     *tag,
                     parser,

--- a/pag-parser/src/lib.rs
+++ b/pag-parser/src/lib.rs
@@ -19,7 +19,7 @@ use utilities::unreachable_branch;
 
 use crate::{
     core_syntax::TermArena,
-    frontend::syntax::construct_parser,
+    frontend::{syntax::construct_parser, FrontendErrors},
     nf::{
         fully_normalize, merge_inactive_rules, remove_unreachable_rules, semi_normalize,
         NormalForms, Tag, TagAssigner,
@@ -35,7 +35,7 @@ pub mod utilities;
 
 pub enum Error<'src> {
     GrammarDefinitionError(GrammarDefinitionError<'src>),
-    FrontendErrors(Vec<WithSpan<'src, frontend::Error<'src>>>),
+    FrontendErrors(FrontendErrors<'src>),
     TypeErrors(Vec<type_system::TypeError<'src>>),
 }
 

--- a/pag-parser/src/nf.rs
+++ b/pag-parser/src/nf.rs
@@ -326,7 +326,7 @@ pub fn merge_inactive_rules<'src, 'nf>(
     let mut table: HashMap<&[&NormalForm], Tag<'src>> = HashMap::new();
     let mut rename = Vec::new();
     for (tag, nf) in nfs.entries.iter() {
-        if !tag.is_versioned() && parser.bindings.get(&tag.symbol).map_or(false, |x| x.active) {
+        if parser.is_active(tag) {
             continue;
         }
         table

--- a/pag-parser/src/nf.rs
+++ b/pag-parser/src/nf.rs
@@ -229,6 +229,11 @@ pub fn semi_normalize_helper<'src, 'p, 'nf>(
         Term::Fix(var, body) => {
             let body_tag = Tag::new(*var);
             semi_normalize_helper(&body.node, body_tag, arena, nfs, assigner, parser);
+            // copy tag for fixpoint
+            if tag != body_tag {
+                let body_nf = nfs.entries.get(&body_tag).unwrap();
+                nfs.entries.insert(tag, body_nf.clone());
+            }
             body_tag
         }
         Term::ParserRef(x) => {

--- a/pag-parser/src/type_system/mod.rs
+++ b/pag-parser/src/type_system/mod.rs
@@ -15,30 +15,25 @@ use std::vec;
 
 use crate::type_system::context::TypeContext;
 use pest::Span;
-use thiserror::Error;
 
 use self::binding_proxy::BindingProxy;
 
 pub mod binding_proxy;
 pub mod context;
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum TypeError<'a> {
-    #[error("sequential uniqueness requirement volidation")]
     SequentialUniquenessViolation {
         lhs: (Span<'a>, Type<'a>),
         rhs: (Span<'a>, Type<'a>),
         total: Span<'a>,
     },
-    #[error("disjunctive uniqueness requirement volidation")]
     DisjunctiveUniquenessViolation {
         lhs: (Span<'a>, Type<'a>),
         rhs: (Span<'a>, Type<'a>),
         total: Span<'a>,
     },
-    #[error("unguarded fixpoint {0}")]
     UnguardedFixpoint(Symbol<'a>, Span<'a>),
-    #[error("unresolved reference {0}")]
     UnresolvedReference(Symbol<'a>, Span<'a>),
 }
 

--- a/pag-parser/src/utilities.rs
+++ b/pag-parser/src/utilities.rs
@@ -13,6 +13,7 @@ impl<'a> Symbol<'a> {
     pub fn new(data: &'a str) -> Self {
         Self(data)
     }
+
     pub fn name(&self) -> &'a str {
         self.0
     }

--- a/tests/arith-expr/arith.pag
+++ b/tests/arith-expr/arith.pag
@@ -10,18 +10,18 @@ lexer {
 }
 
 parser expr {
-    active fixpoint expr
+    active expr
         = mult ~ (PLUS ~ mult)*;
 
-    active fixpoint mult
+    active mult
         = primary ~ (MULT ~ primary)*;
 
-    silent fixpoint primary
+    silent primary
         = special | int | LPAREN ~ expr ~ RPAREN;
 
-    active definition int
+    active int
         = INT;
 
-    active definition special
+    active special
         = SPECIAL;
 }

--- a/tests/sexpr-calculator/sexpr.pag
+++ b/tests/sexpr-calculator/sexpr.pag
@@ -9,15 +9,15 @@ lexer {
 }
 
 parser sexpr {
-    active fixpoint compound
+    active compound
         = LPAREN ~ op ~ (compound | int)* ~ RPAREN;
 
-    active definition op
+    active op
         = PLUS | MULT;
 
-    active definition int
+    active int
         = INT;
 
-    active definition sexpr
+    active sexpr
         = compound | int;
 }


### PR DESCRIPTION
An experimental implementation. Currently, it has some problems:

- No error handling (will complete soon, maybe next PR)
- May generate extra fixpoint marks. For example, it will mark `sexprs` in our `example.pag` as a fixpoint, creating a redundant nested fixpoint node. I haven't come up with a clear solution.

Fixes #46 