### PR TITLE
optimize lut lookahead

### DIFF
--- a/benches/csv/Cargo.toml
+++ b/benches/csv/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+pag-util = { version = "0.1.0-alpha.1", path = "../../pag-util" }
 rand = { version = "0.8" }
 snmalloc-rs = { version = "0.3", features = ["build_cc"] }
 

--- a/benches/json/Cargo.toml
+++ b/benches/json/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 autobenches = false
 
 [dependencies]
+pag-util = { version = "0.1.0-alpha.1", path = "../../pag-util" }
 rand = { version = "0.8" }
 serde_json = "1.0"
 

--- a/pag-lexer/src/lookahead.rs
+++ b/pag-lexer/src/lookahead.rs
@@ -51,6 +51,7 @@ fn generate_lookahead_routine(intervals: &Intervals, kind: Kind) -> TokenStream 
     };
     quote! {
         'lookahead: {
+            unsafe { ::pag_util::assume(idx <= input.len()) };
             for chunk in input[idx..].chunks_exact(16) {
                 use core::simd::*;
                 let data = u8x16::from_slice(chunk);
@@ -90,6 +91,7 @@ fn generate_lookahead_routine(intervals: &Intervals, kind: Kind) -> TokenStream 
         Kind::Negative => quote! { trailing_zeros },
     };
     quote! {
+        unsafe { ::pag_util::assume(idx <= input.len()) };
         for chunk in input[idx..].chunks_exact(16) {
             use core::simd::*;
             let data = u8x16::from_slice(chunk);

--- a/pag-lexer/src/lookahead.rs
+++ b/pag-lexer/src/lookahead.rs
@@ -19,37 +19,9 @@ enum Kind {
 }
 
 fn generate_lut_routine(index: usize) -> TokenStream {
-    // TODO: put the code to `pag_util::lookahead_lut` to reduce stack size under debug build
     let table = index / 8;
     let shift = index % 8;
-    let bit = 1u8 << shift;
-    quote! {
-        'lookahead: {
-            for chunk in input[idx..].chunks_exact(8) {
-                if GLOBAL_LUT[#table][chunk[0] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[1] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[2] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[3] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[4] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[5] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[6] as usize] & #bit == 0 {
-                if GLOBAL_LUT[#table][chunk[7] as usize] & #bit == 0 {
-                    idx += 8; continue; }
-                    idx += 7; break 'lookahead; }
-                    idx += 6; break 'lookahead; }
-                    idx += 5; break 'lookahead; }
-                    idx += 4; break 'lookahead; }
-                    idx += 3; break 'lookahead; }
-                    idx += 2; break 'lookahead; }
-                    idx += 1; break 'lookahead; }
-                break 'lookahead;
-            }
-            idx += input[idx..]
-                .iter()
-                .position(|x| GLOBAL_LUT[#table][*x as usize] & #bit > 0)
-                .unwrap_or(input[idx..].len());
-        }
-    }
+    quote! { idx = ::pag_util::lookahead_lut(input, idx, &GLOBAL_LUT[#table], #shift); }
 }
 
 #[cfg(not(target_arch = "aarch64"))]

--- a/pag-lexer/src/lookahead.rs
+++ b/pag-lexer/src/lookahead.rs
@@ -19,15 +19,36 @@ enum Kind {
 }
 
 fn generate_lut_routine(index: usize) -> TokenStream {
+    // TODO: put the code to `pag_util::lookahead_lut` to reduce stack size under debug build
     let table = index / 8;
     let shift = index % 8;
     let bit = 1u8 << shift;
     quote! {
-        idx = idx
-            + input[idx..]
+        'lookahead: {
+            for chunk in input[idx..].chunks_exact(8) {
+                if GLOBAL_LUT[#table][chunk[0] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[1] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[2] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[3] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[4] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[5] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[6] as usize] & #bit == 0 {
+                if GLOBAL_LUT[#table][chunk[7] as usize] & #bit == 0 {
+                    idx += 8; continue; }
+                    idx += 7; break 'lookahead; }
+                    idx += 6; break 'lookahead; }
+                    idx += 5; break 'lookahead; }
+                    idx += 4; break 'lookahead; }
+                    idx += 3; break 'lookahead; }
+                    idx += 2; break 'lookahead; }
+                    idx += 1; break 'lookahead; }
+                break 'lookahead;
+            }
+            idx += input[idx..]
                 .iter()
                 .position(|x| GLOBAL_LUT[#table][*x as usize] & #bit > 0)
-                .unwrap_or(input.len() - idx);
+                .unwrap_or(input[idx..].len());
+        }
     }
 }
 

--- a/pag-lexer/src/vector.rs
+++ b/pag-lexer/src/vector.rs
@@ -142,6 +142,7 @@ impl Vector {
                 let on_success = &success_actions[rule_idx];
                 return quote! {
                     State::#label => {
+                        unsafe { ::pag_util::assume(idx <= input.len()) };
                         if input[idx..].starts_with(#literal) {
                             cursor = idx + #length;
                             #on_success

--- a/pag-util/Cargo.toml
+++ b/pag-util/Cargo.toml
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Paguroidea Developers
+#
+# Licensed under the Apache License, Version 2.0
+# <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+# license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. All files in the project carrying such notice may not be copied,
+# modified, or distributed except according to those terms.
+
+[package]
+name = "pag-util"
+keywords = ["parser", "cfg", "grammar"]
+description = "Parser-lexer fusion generator (utilities)"
+documentation = "https://docs.rs/pag-util/"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+exclude.workspace = true
+categories.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+readme.workspace = true

--- a/pag-util/src/lib.rs
+++ b/pag-util/src/lib.rs
@@ -1,0 +1,40 @@
+use std::hint::unreachable_unchecked;
+
+#[doc(hidden)]
+#[inline]
+pub unsafe fn assume(cond: bool) {
+    if !cond {
+        unreachable_unchecked()
+    }
+}
+
+#[doc(hidden)]
+#[inline]
+#[rustfmt::skip]
+pub fn lookahead_lut(input: &[u8], mut idx: usize, table: &[u8; 256], shift: usize) -> usize {
+    let mask = 1 << shift;
+    for chunk in input[idx..].chunks_exact(8) {
+        if table[chunk[0] as usize] & mask == 0 {
+        if table[chunk[1] as usize] & mask == 0 {
+        if table[chunk[2] as usize] & mask == 0 {
+        if table[chunk[3] as usize] & mask == 0 {
+        if table[chunk[4] as usize] & mask == 0 {
+        if table[chunk[5] as usize] & mask == 0 {
+        if table[chunk[6] as usize] & mask == 0 {
+        if table[chunk[7] as usize] & mask == 0 {
+            idx += 8; continue; }
+            idx += 7; return idx; }
+            idx += 6; return idx; }
+            idx += 5; return idx; }
+            idx += 4; return idx; }
+            idx += 3; return idx; }
+            idx += 2; return idx; }
+            idx += 1; return idx; }
+        return idx;
+    }
+    unsafe { assume(idx <= input.len()) };
+    idx + input[idx..]
+        .iter()
+        .position(|x| table[*x as usize] & mask > 0)
+        .unwrap_or(input[idx..].len())
+}

--- a/pag-util/src/lib.rs
+++ b/pag-util/src/lib.rs
@@ -13,6 +13,7 @@ pub unsafe fn assume(cond: bool) {
 #[rustfmt::skip]
 pub fn lookahead_lut(input: &[u8], mut idx: usize, table: &[u8; 256], shift: usize) -> usize {
     let mask = 1 << shift;
+    unsafe { assume(idx <= input.len()) };
     for chunk in input[idx..].chunks_exact(8) {
         if table[chunk[0] as usize] & mask == 0 {
         if table[chunk[1] as usize] & mask == 0 {

--- a/tests/arith-expr/Cargo.toml
+++ b/tests/arith-expr/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 publish = false
 
 [dependencies]
+pag-util = { version = "0.1.0-alpha.1", path = "../../pag-util" }
 rand = { version = "0.8" }
 
 [build-dependencies]

--- a/tests/sexpr-calculator/Cargo.toml
+++ b/tests/sexpr-calculator/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 publish = false
 
 [dependencies]
+pag-util = { version = "0.1.0-alpha.1", path = "../../pag-util" }
 rand = { version = "0.8" }
 
 [build-dependencies]

--- a/tests/tokenizer/Cargo.toml
+++ b/tests/tokenizer/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+pag-util = { version = "0.1.0-alpha.1", path = "../../pag-util" }
 rand = { version = "0.8" }
 
 [build-dependencies]


### PR DESCRIPTION
The `sexpr-calculator` test will trigger stack overflow under debug build if we set lookahead `limit` to `0`. Could you please take a look? @SchrodingerZhu 